### PR TITLE
Replace type defines with scoped enum to avoid collisions

### DIFF
--- a/src/constants/constants.h
+++ b/src/constants/constants.h
@@ -99,6 +99,22 @@ constexpr float critical_dose_c         = 2.8141f;
 constexpr float reduced_critical_dose_b = critical_dose_b / 2.f;
 } // namespace electron_dose
 
+// Fundamental data types used for job arguments, parameters, and data serialization
+namespace fundamental_type {
+enum Enum : int {
+    none_t             = 0,
+    text_t             = 1,
+    integer_t          = 2,
+    float_t            = 3,
+    bool_t             = 4,
+    long_t             = 5,
+    double_t           = 6,
+    char_t             = 7,
+    variable_length_t  = 8,
+    integer_unsigned_t = 9
+};
+} // namespace fundamental_type
+
 // To ensure data base type parity, force int type (even though this should be the default).
 namespace job_type {
 enum Enum : int {

--- a/src/core/cistem_parameters.cpp
+++ b/src/core/cistem_parameters.cpp
@@ -2,6 +2,8 @@
 #include <wx/arrimpl.cpp> // this is a magic incantation which must be done!
 WX_DEFINE_OBJARRAY(ArrayOfcisTEMParameterLines);
 
+using c_ft = cistem::fundamental_type::Enum;
+
 // **************************************
 // ADDING NEW COLUMNS TO THE DATA FILES..
 // **************************************
@@ -27,13 +29,13 @@ cistem_parameters.cpp
 	if (parameters_to_write.total_exposure == true)
 	{
 		bitmask_identifier = TOTAL_EXPOSURE;
-		data_type = VARIABLE_LENGTH;
+		data_type = c_ft::variable_length_t;
 		fwrite ( &bitmask_identifier, sizeof(long), 1, cisTEM_bin_file );
 		fwrite ( &data_type, sizeof(char), 1, cisTEM_bin_file );
 	}
 
 You will need to change parameters_to_write.total_exposure to your variable, bitmask_identifier = to your identifier and data_type to your
-data type (it can be INTEGER, UNSIGNED_INTEGER, FLOAT, LONG, BYTE, DOUBLE or VARIABLE)
+data type (it can be cistem::fundamental_type::integer_t, integer_unsigned_t, float_t, long_t, char_t, double_t or variable_length_t)
 
 You will then have to add it to loop where the data values are written out - this currently ends at line ~996, and looks like this :-
 
@@ -780,15 +782,15 @@ void cisTEMParameters::WriteTocisTEMBinaryFile(wxString wanted_filename, int fir
     // write an identifier for each column based on bit mask values above, after the identifier which is a long, write the type
     // of the data.  This is needed so that we can skip that contains unknown columns (e.g. from a later version of cisTEM).
 
-    // The data type can be :-
+    // The data type can be (using cistem::fundamental_type::Enum) :-
 
-    // INTEGER
-    // UNSIGNED_INTEGER
-    // FLOAT
-    // LONG
-    // BYTE
-    // DOUBLE
-    // VARIABLE - variable will be an integer first, which tells us how many bytes the next sections is.
+    // cistem::fundamental_type::integer_t
+    // cistem::fundamental_type::integer_unsigned_t
+    // cistem::fundamental_type::float_t
+    // cistem::fundamental_type::long_t
+    // cistem::fundamental_type::char_t
+    // cistem::fundamental_type::double_t
+    // cistem::fundamental_type::variable_length_t - variable will be an integer first, which tells us how many bytes the next sections is.
 
     long bitmask_identifier;
     char data_type;
@@ -800,7 +802,7 @@ void cisTEMParameters::WriteTocisTEMBinaryFile(wxString wanted_filename, int fir
 
     if ( parameters_to_write.position_in_stack == true ) {
         bitmask_identifier = POSITION_IN_STACK;
-        data_type          = INTEGER_UNSIGNED;
+        data_type          = c_ft::integer_unsigned_t;
 
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
@@ -808,7 +810,7 @@ void cisTEMParameters::WriteTocisTEMBinaryFile(wxString wanted_filename, int fir
 
     if ( parameters_to_write.psi == true ) {
         bitmask_identifier = PSI;
-        data_type          = FLOAT;
+        data_type          = c_ft::float_t;
 
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
@@ -816,231 +818,231 @@ void cisTEMParameters::WriteTocisTEMBinaryFile(wxString wanted_filename, int fir
 
     if ( parameters_to_write.theta == true ) {
         bitmask_identifier = THETA;
-        data_type          = FLOAT;
+        data_type          = c_ft::float_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }
 
     if ( parameters_to_write.phi == true ) {
         bitmask_identifier = PHI;
-        data_type          = FLOAT;
+        data_type          = c_ft::float_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }
 
     if ( parameters_to_write.x_shift == true ) {
         bitmask_identifier = X_SHIFT;
-        data_type          = FLOAT;
+        data_type          = c_ft::float_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }
 
     if ( parameters_to_write.y_shift == true ) {
         bitmask_identifier = Y_SHIFT;
-        data_type          = FLOAT;
+        data_type          = c_ft::float_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }
 
     if ( parameters_to_write.defocus_1 == true ) {
         bitmask_identifier = DEFOCUS_1;
-        data_type          = FLOAT;
+        data_type          = c_ft::float_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }
 
     if ( parameters_to_write.defocus_2 == true ) {
         bitmask_identifier = DEFOCUS_2;
-        data_type          = FLOAT;
+        data_type          = c_ft::float_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }
 
     if ( parameters_to_write.defocus_angle == true ) {
         bitmask_identifier = DEFOCUS_ANGLE;
-        data_type          = FLOAT;
+        data_type          = c_ft::float_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }
 
     if ( parameters_to_write.phase_shift == true ) {
         bitmask_identifier = PHASE_SHIFT;
-        data_type          = FLOAT;
+        data_type          = c_ft::float_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }
 
     if ( parameters_to_write.image_is_active == true ) {
         bitmask_identifier = IMAGE_IS_ACTIVE;
-        data_type          = INTEGER;
+        data_type          = c_ft::integer_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }
 
     if ( parameters_to_write.occupancy == true ) {
         bitmask_identifier = OCCUPANCY;
-        data_type          = FLOAT;
+        data_type          = c_ft::float_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }
 
     if ( parameters_to_write.logp == true ) {
         bitmask_identifier = LOGP;
-        data_type          = FLOAT;
+        data_type          = c_ft::float_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }
 
     if ( parameters_to_write.sigma == true ) {
         bitmask_identifier = SIGMA;
-        data_type          = FLOAT;
+        data_type          = c_ft::float_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }
 
     if ( parameters_to_write.score == true ) {
         bitmask_identifier = SCORE;
-        data_type          = FLOAT;
+        data_type          = c_ft::float_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }
 
     if ( parameters_to_write.score_change == true ) {
         bitmask_identifier = SCORE_CHANGE;
-        data_type          = FLOAT;
+        data_type          = c_ft::float_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }
 
     if ( parameters_to_write.pixel_size == true ) {
         bitmask_identifier = PIXEL_SIZE;
-        data_type          = FLOAT;
+        data_type          = c_ft::float_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }
 
     if ( parameters_to_write.microscope_voltage_kv == true ) {
         bitmask_identifier = MICROSCOPE_VOLTAGE;
-        data_type          = FLOAT;
+        data_type          = c_ft::float_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }
 
     if ( parameters_to_write.microscope_spherical_aberration_mm == true ) {
         bitmask_identifier = MICROSCOPE_CS;
-        data_type          = FLOAT;
+        data_type          = c_ft::float_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }
 
     if ( parameters_to_write.amplitude_contrast == true ) {
         bitmask_identifier = AMPLITUDE_CONTRAST;
-        data_type          = FLOAT;
+        data_type          = c_ft::float_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }
 
     if ( parameters_to_write.beam_tilt_x == true ) {
         bitmask_identifier = BEAM_TILT_X;
-        data_type          = FLOAT;
+        data_type          = c_ft::float_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }
 
     if ( parameters_to_write.beam_tilt_y == true ) {
         bitmask_identifier = BEAM_TILT_Y;
-        data_type          = FLOAT;
+        data_type          = c_ft::float_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }
 
     if ( parameters_to_write.image_shift_x == true ) {
         bitmask_identifier = IMAGE_SHIFT_X;
-        data_type          = FLOAT;
+        data_type          = c_ft::float_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }
 
     if ( parameters_to_write.image_shift_y == true ) {
         bitmask_identifier = IMAGE_SHIFT_Y;
-        data_type          = FLOAT;
+        data_type          = c_ft::float_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }
 
     if ( parameters_to_write.best_2d_class == true ) {
         bitmask_identifier = BEST_2D_CLASS;
-        data_type          = INTEGER;
+        data_type          = c_ft::integer_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }
 
     if ( parameters_to_write.beam_tilt_group == true ) {
         bitmask_identifier = BEAM_TILT_GROUP;
-        data_type          = INTEGER;
+        data_type          = c_ft::integer_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }
 
     if ( parameters_to_write.stack_filename == true ) {
         bitmask_identifier = STACK_FILENAME;
-        data_type          = VARIABLE_LENGTH;
+        data_type          = c_ft::variable_length_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }
 
     if ( parameters_to_write.original_image_filename == true ) {
         bitmask_identifier = ORIGINAL_IMAGE_FILENAME;
-        data_type          = VARIABLE_LENGTH;
+        data_type          = c_ft::variable_length_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }
 
     if ( parameters_to_write.reference_3d_filename == true ) {
         bitmask_identifier = REFERENCE_3D_FILENAME;
-        data_type          = VARIABLE_LENGTH;
+        data_type          = c_ft::variable_length_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }
 
     if ( parameters_to_write.particle_group == true ) {
         bitmask_identifier = PARTICLE_GROUP;
-        data_type          = INTEGER;
+        data_type          = c_ft::integer_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }
 
     if ( parameters_to_write.assigned_subset == true ) {
         bitmask_identifier = ASSIGNED_SUBSET;
-        data_type          = INTEGER;
+        data_type          = c_ft::integer_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }
 
     if ( parameters_to_write.pre_exposure == true ) {
         bitmask_identifier = PRE_EXPOSURE;
-        data_type          = FLOAT;
+        data_type          = c_ft::float_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }
 
     if ( parameters_to_write.total_exposure == true ) {
         bitmask_identifier = TOTAL_EXPOSURE;
-        data_type          = FLOAT;
+        data_type          = c_ft::float_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }
 
     if ( parameters_to_write.original_x_position == true ) {
         bitmask_identifier = ORIGINAL_X_POSITION;
-        data_type          = FLOAT;
+        data_type          = c_ft::float_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }
 
     if ( parameters_to_write.original_y_position == true ) {
         bitmask_identifier = ORIGINAL_Y_POSITION;
-        data_type          = FLOAT;
+        data_type          = c_ft::float_t;
         fwrite(&bitmask_identifier, sizeof(long), 1, cisTEM_bin_file);
         fwrite(&data_type, sizeof(char), 1, cisTEM_bin_file);
     }

--- a/src/core/cistem_star_file_reader.cpp
+++ b/src/core/cistem_star_file_reader.cpp
@@ -1,5 +1,7 @@
 #include "core_headers.h"
 
+using c_ft = cistem::fundamental_type::Enum;
+
 //TODO : Currently, any strings with spaces will cause the star file (but not binary) reader to break - needs to be fixed.
 
 // ADDING A NEW COLUMN
@@ -1527,37 +1529,37 @@ bool cisTEMStarFileReader::ReadBinaryFile(wxString wanted_filename, ArrayOfcisTE
                 if ( current_line == 0 )
                     wxPrintf("Unknown Column Type in Binary File (%li) - it will be ignored.\n");
 
-                if ( column_data_types[current_column] == INTEGER ) {
+                if ( column_data_types[current_column] == c_ft::integer_t ) {
                     int buffer_int;
                     if ( SafelyReadFromBinaryBufferIntoInteger(buffer_int) == false )
                         return false;
                 }
-                else if ( column_data_types[current_column] == INTEGER_UNSIGNED ) {
+                else if ( column_data_types[current_column] == c_ft::integer_unsigned_t ) {
                     unsigned int buffer_int;
                     if ( SafelyReadFromBinaryBufferIntoUnsignedInteger(buffer_int) == false )
                         return false;
                 }
-                else if ( column_data_types[current_column] == FLOAT ) {
+                else if ( column_data_types[current_column] == c_ft::float_t ) {
                     float buffer_float;
                     if ( SafelyReadFromBinaryBufferIntoFloat(buffer_float) == false )
                         return false;
                 }
-                else if ( column_data_types[current_column] == LONG ) {
+                else if ( column_data_types[current_column] == c_ft::long_t ) {
                     long buffer_long;
                     if ( SafelyReadFromBinaryBufferIntoLong(buffer_long) == false )
                         return false;
                 }
-                else if ( column_data_types[current_column] == DOUBLE ) {
+                else if ( column_data_types[current_column] == c_ft::double_t ) {
                     double buffer_double;
                     if ( SafelyReadFromBinaryBufferIntoDouble(buffer_double) == false )
                         return false;
                 }
-                else if ( column_data_types[current_column] == CHAR ) {
+                else if ( column_data_types[current_column] == c_ft::char_t ) {
                     char buffer_char;
                     if ( SafelyReadFromBinaryBufferIntoChar(buffer_char) == false )
                         return false;
                 }
-                else if ( column_data_types[current_column] == VARIABLE_LENGTH ) {
+                else if ( column_data_types[current_column] == c_ft::variable_length_t ) {
                     wxString buffer_string;
                     if ( SafelyReadFromBinaryBufferIntowxString(buffer_string) == false )
                         return false;

--- a/src/core/defines.h
+++ b/src/core/defines.h
@@ -17,19 +17,6 @@
 #define SOCKET_FLAGS wxSOCKET_WAITALL | wxSOCKET_BLOCK
 //#define SOCKET_FLAGS wxSOCKET_WAITALL
 
-// data types.. (moved from job_packager.h)
-
-#define NONE        	 0
-#define TEXT			 1
-#define INTEGER			 2
-#define FLOAT			 3
-#define BOOL	 	 	 4
-#define LONG        	 5
-#define DOUBLE      	 6
-#define CHAR			 7
-#define VARIABLE_LENGTH  8
-#define INTEGER_UNSIGNED 9
-
 // Types of noise distributions
 namespace cistem {
 

--- a/src/core/job_packager.cpp
+++ b/src/core/job_packager.cpp
@@ -1,5 +1,7 @@
 #include "core_headers.h"
 
+using c_ft = cistem::fundamental_type::Enum;
+
 bool JobPackage::SendJobPackage(wxSocketBase* socket) // package the whole object into a single char stream which can be decoded at the other end..
 {
     SETUP_SOCKET_CODES
@@ -237,10 +239,10 @@ bool JobPackage::SendJobPackage(wxSocketBase* socket) // package the whole objec
         for ( argument_counter = 0; argument_counter < jobs[job_counter].number_of_arguments; argument_counter++ ) {
             // ok, what is this argument..
 
-            if ( jobs[job_counter].arguments[argument_counter].type_of_argument == INTEGER ) {
+            if ( jobs[job_counter].arguments[argument_counter].type_of_argument == c_ft::integer_t ) {
                 // set the descriptor byte
 
-                transfer_buffer[byte_counter] = INTEGER;
+                transfer_buffer[byte_counter] = c_ft::integer_t;
                 byte_counter++;
 
                 // set the value of the integer..
@@ -257,10 +259,10 @@ bool JobPackage::SendJobPackage(wxSocketBase* socket) // package the whole objec
                 transfer_buffer[byte_counter] = char_pointer[3];
                 byte_counter++;
             }
-            else if ( jobs[job_counter].arguments[argument_counter].type_of_argument == FLOAT ) {
+            else if ( jobs[job_counter].arguments[argument_counter].type_of_argument == c_ft::float_t ) {
                 // set the descriptor byte
 
-                transfer_buffer[byte_counter] = FLOAT;
+                transfer_buffer[byte_counter] = c_ft::float_t;
                 byte_counter++;
 
                 // set the value of the float..
@@ -277,10 +279,10 @@ bool JobPackage::SendJobPackage(wxSocketBase* socket) // package the whole objec
                 transfer_buffer[byte_counter] = char_pointer[3];
                 byte_counter++;
             }
-            else if ( jobs[job_counter].arguments[argument_counter].type_of_argument == BOOL ) {
+            else if ( jobs[job_counter].arguments[argument_counter].type_of_argument == c_ft::bool_t ) {
                 // set the descriptor byte
 
-                transfer_buffer[byte_counter] = BOOL;
+                transfer_buffer[byte_counter] = c_ft::bool_t;
                 byte_counter++;
 
                 // set the value of the bool..
@@ -288,10 +290,10 @@ bool JobPackage::SendJobPackage(wxSocketBase* socket) // package the whole objec
                 transfer_buffer[byte_counter] = (unsigned char)jobs[job_counter].arguments[argument_counter].ReturnBoolArgument( );
                 byte_counter++;
             }
-            else if ( jobs[job_counter].arguments[argument_counter].type_of_argument == TEXT ) {
+            else if ( jobs[job_counter].arguments[argument_counter].type_of_argument == c_ft::text_t ) {
                 // set the descriptor byte
 
-                transfer_buffer[byte_counter] = TEXT;
+                transfer_buffer[byte_counter] = c_ft::text_t;
                 byte_counter++;
 
                 // add the length of the string..
@@ -627,7 +629,7 @@ bool JobPackage::ReceiveJobPackage(wxSocketBase* socket) {
 
             byte_counter++;
 
-            if ( jobs[job_counter].arguments[argument_counter].type_of_argument == INTEGER ) {
+            if ( jobs[job_counter].arguments[argument_counter].type_of_argument == c_ft::integer_t ) {
                 // read the value of the integer..
 
                 char_pointer = (unsigned char*)&temp_int;
@@ -643,7 +645,7 @@ bool JobPackage::ReceiveJobPackage(wxSocketBase* socket) {
 
                 jobs[job_counter].arguments[argument_counter].SetIntArgument(temp_int);
             }
-            else if ( jobs[job_counter].arguments[argument_counter].type_of_argument == FLOAT ) {
+            else if ( jobs[job_counter].arguments[argument_counter].type_of_argument == c_ft::float_t ) {
                 // read the value of the float..
 
                 char_pointer = (unsigned char*)&temp_float;
@@ -659,11 +661,11 @@ bool JobPackage::ReceiveJobPackage(wxSocketBase* socket) {
 
                 jobs[job_counter].arguments[argument_counter].SetFloatArgument(temp_float);
             }
-            else if ( jobs[job_counter].arguments[argument_counter].type_of_argument == BOOL ) {
+            else if ( jobs[job_counter].arguments[argument_counter].type_of_argument == c_ft::bool_t ) {
                 jobs[job_counter].arguments[argument_counter].SetBoolArgument(bool(transfer_buffer[byte_counter]));
                 byte_counter++;
             }
-            else if ( jobs[job_counter].arguments[argument_counter].type_of_argument == TEXT ) {
+            else if ( jobs[job_counter].arguments[argument_counter].type_of_argument == c_ft::text_t ) {
                 // read length of command string
 
                 char_pointer = (unsigned char*)&length_of_string;
@@ -910,10 +912,10 @@ bool RunJob::SendJob(wxSocketBase* socket) {
     for ( argument_counter = 0; argument_counter < number_of_arguments; argument_counter++ ) {
         // ok, what is this argument..
 
-        if ( arguments[argument_counter].type_of_argument == INTEGER ) {
+        if ( arguments[argument_counter].type_of_argument == c_ft::integer_t ) {
             // set the descriptor byte
 
-            transfer_buffer[byte_counter] = INTEGER;
+            transfer_buffer[byte_counter] = c_ft::integer_t;
             byte_counter++;
 
             // set the value of the integer..
@@ -930,10 +932,10 @@ bool RunJob::SendJob(wxSocketBase* socket) {
             transfer_buffer[byte_counter] = char_pointer[3];
             byte_counter++;
         }
-        else if ( arguments[argument_counter].type_of_argument == FLOAT ) {
+        else if ( arguments[argument_counter].type_of_argument == c_ft::float_t ) {
             // set the descriptor byte
 
-            transfer_buffer[byte_counter] = FLOAT;
+            transfer_buffer[byte_counter] = c_ft::float_t;
             byte_counter++;
 
             // set the value of the float..
@@ -950,10 +952,10 @@ bool RunJob::SendJob(wxSocketBase* socket) {
             transfer_buffer[byte_counter] = char_pointer[3];
             byte_counter++;
         }
-        else if ( arguments[argument_counter].type_of_argument == BOOL ) {
+        else if ( arguments[argument_counter].type_of_argument == c_ft::bool_t ) {
             // set the descriptor byte
 
-            transfer_buffer[byte_counter] = BOOL;
+            transfer_buffer[byte_counter] = c_ft::bool_t;
             byte_counter++;
 
             // set the value of the bool..
@@ -961,10 +963,10 @@ bool RunJob::SendJob(wxSocketBase* socket) {
             transfer_buffer[byte_counter] = (unsigned char)arguments[argument_counter].ReturnBoolArgument( );
             byte_counter++;
         }
-        else if ( arguments[argument_counter].type_of_argument == TEXT ) {
+        else if ( arguments[argument_counter].type_of_argument == c_ft::text_t ) {
             // set the descriptor byte
 
-            transfer_buffer[byte_counter] = TEXT;
+            transfer_buffer[byte_counter] = c_ft::text_t;
             byte_counter++;
 
             // add the length of the string..
@@ -1121,7 +1123,7 @@ bool RunJob::RecieveJob(wxSocketBase* socket) {
 
         byte_counter++;
 
-        if ( arguments[argument_counter].type_of_argument == INTEGER ) {
+        if ( arguments[argument_counter].type_of_argument == c_ft::integer_t ) {
             // read the value of the integer..
             char_pointer = (unsigned char*)&temp_int;
 
@@ -1136,7 +1138,7 @@ bool RunJob::RecieveJob(wxSocketBase* socket) {
 
             arguments[argument_counter].SetIntArgument(temp_int);
         }
-        else if ( arguments[argument_counter].type_of_argument == FLOAT ) {
+        else if ( arguments[argument_counter].type_of_argument == c_ft::float_t ) {
             // read the value of the float..
             char_pointer = (unsigned char*)&temp_float;
 
@@ -1151,12 +1153,12 @@ bool RunJob::RecieveJob(wxSocketBase* socket) {
 
             arguments[argument_counter].SetFloatArgument(temp_float);
         }
-        else if ( arguments[argument_counter].type_of_argument == BOOL ) {
+        else if ( arguments[argument_counter].type_of_argument == c_ft::bool_t ) {
 
             arguments[argument_counter].SetBoolArgument(bool(transfer_buffer[byte_counter]));
             byte_counter++;
         }
-        else if ( arguments[argument_counter].type_of_argument == TEXT ) {
+        else if ( arguments[argument_counter].type_of_argument == c_ft::text_t ) {
             // read length of command string
 
             char_pointer = (unsigned char*)&length_of_string;
@@ -1273,16 +1275,16 @@ wxString RunJob::PrintAllArgumentsTowxString( ) {
     wxString string_to_return = "\n";
 
     for ( int counter = 0; counter < number_of_arguments; counter++ ) {
-        if ( arguments[counter].type_of_argument == TEXT ) {
+        if ( arguments[counter].type_of_argument == c_ft::text_t ) {
             string_to_return += wxString::Format("Argument %3i is a string   : %s\n", counter, arguments[counter].ReturnStringArgument( ));
         }
-        else if ( arguments[counter].type_of_argument == INTEGER ) {
+        else if ( arguments[counter].type_of_argument == c_ft::integer_t ) {
             string_to_return += wxString::Format("Argument %3i is an integer : %i\n", counter, arguments[counter].ReturnIntegerArgument( ));
         }
-        else if ( arguments[counter].type_of_argument == FLOAT ) {
+        else if ( arguments[counter].type_of_argument == c_ft::float_t ) {
             string_to_return += wxString::Format("Argument %3i is a float    : %f\n", counter, arguments[counter].ReturnFloatArgument( ));
         }
-        else if ( arguments[counter].type_of_argument == BOOL ) {
+        else if ( arguments[counter].type_of_argument == c_ft::bool_t ) {
             string_to_return += wxString::Format("Argument %3i is a bool     : ", counter);
 
             if ( arguments[counter].ReturnBoolArgument( ) == true )
@@ -1325,16 +1327,16 @@ RunJob& RunJob::operator=(const RunJob* other_job) {
         has_been_run = other_job->has_been_run;
 
         for ( int counter = 0; counter < number_of_arguments; counter++ ) {
-            if ( other_job->arguments[counter].type_of_argument == TEXT ) {
+            if ( other_job->arguments[counter].type_of_argument == c_ft::text_t ) {
                 arguments[counter].SetStringArgument(other_job->arguments[counter].ReturnStringArgument( ).c_str( ));
             }
-            else if ( other_job->arguments[counter].type_of_argument == INTEGER ) {
+            else if ( other_job->arguments[counter].type_of_argument == c_ft::integer_t ) {
                 arguments[counter].SetIntArgument(other_job->arguments[counter].ReturnIntegerArgument( ));
             }
-            else if ( other_job->arguments[counter].type_of_argument == FLOAT ) {
+            else if ( other_job->arguments[counter].type_of_argument == c_ft::float_t ) {
                 arguments[counter].SetFloatArgument(other_job->arguments[counter].ReturnFloatArgument( ));
             }
-            else if ( other_job->arguments[counter].type_of_argument == BOOL ) {
+            else if ( other_job->arguments[counter].type_of_argument == c_ft::bool_t ) {
                 arguments[counter].SetBoolArgument(other_job->arguments[counter].ReturnBoolArgument( ));
             }
         }
@@ -1350,7 +1352,7 @@ RunJob& RunJob::operator=(const RunJob& other_job) {
 
 RunArgument::RunArgument( ) {
     is_allocated     = false;
-    type_of_argument = NONE;
+    type_of_argument = c_ft::none_t;
     string_argument  = NULL;
     integer_argument = NULL;
     float_argument   = NULL;
@@ -1363,24 +1365,24 @@ RunArgument::~RunArgument( ) {
 }
 
 void RunArgument::Deallocate( ) {
-    if ( type_of_argument == TEXT )
+    if ( type_of_argument == c_ft::text_t )
         delete string_argument;
-    else if ( type_of_argument == INTEGER )
+    else if ( type_of_argument == c_ft::integer_t )
         delete integer_argument;
-    else if ( type_of_argument == FLOAT )
+    else if ( type_of_argument == c_ft::float_t )
         delete float_argument;
-    else if ( type_of_argument == BOOL )
+    else if ( type_of_argument == c_ft::bool_t )
         delete bool_argument;
 
     is_allocated = false;
 }
 
 long RunArgument::ReturnEncodedByteTransferSize( ) {
-    MyDebugAssertTrue(type_of_argument != NONE, "Can't calculate size of a nothing argument!!");
+    MyDebugAssertTrue(type_of_argument != c_ft::none_t, "Can't calculate size of a nothing argument!!");
 
-    if ( type_of_argument == TEXT )
+    if ( type_of_argument == c_ft::text_t )
         return string_argument->length( ) + 4 + 1; // descriptor byte + length of string (4 bytes) + 1 byte per character
-    else if ( type_of_argument == BOOL )
+    else if ( type_of_argument == c_ft::bool_t )
         return 2; // descriptor bytes + bool bytes
     else
         return 5; // descriptor byte + 4 data bytes
@@ -1390,7 +1392,7 @@ void RunArgument::SetStringArgument(const char* wanted_text) {
     if ( is_allocated == true )
         Deallocate( );
 
-    type_of_argument   = TEXT;
+    type_of_argument   = c_ft::text_t;
     string_argument    = new std::string;
     string_argument[0] = wanted_text;
     is_allocated       = true;
@@ -1400,7 +1402,7 @@ void RunArgument::SetIntArgument(int wanted_argument) {
     if ( is_allocated == true )
         Deallocate( );
 
-    type_of_argument    = INTEGER;
+    type_of_argument    = c_ft::integer_t;
     integer_argument    = new int;
     integer_argument[0] = wanted_argument;
     is_allocated        = true;
@@ -1410,7 +1412,7 @@ void RunArgument::SetFloatArgument(float wanted_argument) {
     if ( is_allocated == true )
         Deallocate( );
 
-    type_of_argument  = FLOAT;
+    type_of_argument  = c_ft::float_t;
     float_argument    = new float;
     float_argument[0] = wanted_argument;
     is_allocated      = true;
@@ -1420,7 +1422,7 @@ void RunArgument::SetBoolArgument(bool wanted_argument) {
     if ( is_allocated == true )
         Deallocate( );
 
-    type_of_argument = BOOL;
+    type_of_argument = c_ft::bool_t;
     bool_argument    = new bool;
     bool_argument[0] = wanted_argument;
     is_allocated     = true;

--- a/src/core/job_packager.h
+++ b/src/core/job_packager.h
@@ -1,4 +1,5 @@
 
+using c_ft = cistem::fundamental_type::Enum;
 
 // we need a header to describe how to decode the stream. - which i'm about to make up off the top of my head..  SENDER AND RECEIVER MUST HAVE THE SAME ENDIANESS
 
@@ -37,22 +38,22 @@ class RunArgument {
     void SetBoolArgument(bool wanted_argument);
 
     inline std::string ReturnStringArgument( ) {
-        MyDebugAssertTrue(type_of_argument == TEXT, "Returning wrong type!");
+        MyDebugAssertTrue(type_of_argument == c_ft::text_t, "Returning wrong type!");
         return string_argument[0];
     }
 
     inline int ReturnIntegerArgument( ) {
-        MyDebugAssertTrue(type_of_argument == INTEGER, "Returning wrong type!");
+        MyDebugAssertTrue(type_of_argument == c_ft::integer_t, "Returning wrong type!");
         return integer_argument[0];
     }
 
     inline float ReturnFloatArgument( ) {
-        MyDebugAssertTrue(type_of_argument == FLOAT, "Returning wrong type!");
+        MyDebugAssertTrue(type_of_argument == c_ft::float_t, "Returning wrong type!");
         return float_argument[0];
     }
 
     inline bool ReturnBoolArgument( ) {
-        MyDebugAssertTrue(type_of_argument == BOOL, "Returning wrong type!");
+        MyDebugAssertTrue(type_of_argument == c_ft::bool_t, "Returning wrong type!");
         return bool_argument[0];
     }
 


### PR DESCRIPTION
# Description

Replace preprocessor defines for fundamental data types with a scoped enum to prevent naming collisions with external projects.

The global preprocessor defines (`NONE`, `TEXT`, `INTEGER`, `FLOAT`, `BOOL`, `LONG`, `DOUBLE`, `CHAR`, `VARIABLE_LENGTH`, `INTEGER_UNSIGNED`) were causing naming conflicts when cisTEM headers were included in other projects. These common names (especially `TEXT` and `BOOL`) collide with Windows headers and other libraries.

**Why:** Replaced with `cistem::fundamental_type::Enum` scoped enum using `_t` suffix naming convention (e.g., `text_t`, `integer_t`, `float_t`). This follows modern C++ best practices and ensures names are properly scoped to the `cistem` namespace, eliminating potential collisions.

**Implementation:** Added `using c_ft = cistem::fundamental_type::Enum;` alias in implementation files for clean, concise syntax throughout the codebase.

Fixes # (if applicable)

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [x] yes
- [ ] no

# Which compilers were tested

- [ ] g++
- [x] icpc
- [ ] clang
- [ ] other (please specify)

# These changes are isolated to the

- [ ] gui
- [x] core library
- [ ] gpu core library
- [ ] program it modifies

# How has the functionality been tested?

- [ ] Tested manually from GUI
- [ ] Tested manually from CLI
- [x] Passed console tests
- [ ] Passed samples functional testing (failed due to unrelated GPU projection issue)
- [ ] other (please specify)

# Checklist:

- [x] I have not changed anything that did not need to be changed
- [x] I have performed a self-review of my own code
- [x] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)